### PR TITLE
Subsurface fixes

### DIFF
--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -147,16 +147,7 @@ wl_cb_subcompositor_get_subsurface(struct wl_client *client, struct wl_resource 
       return;
 
    wlc_resource_implement(r, &wl_subsurface_implementation, (void*)surface);
-
-   struct wlc_surface *subsurface = convert_from_wlc_resource(surface, "surface"),
-                      *parent_surface = convert_from_wlc_resource(parent, "surface");
-
-   chck_iter_pool_push_front(&parent_surface->subsurface_list, &surface);
-
-   subsurface->output = parent_surface->output;
-   subsurface->view = parent_surface->view;
-
-   wlc_surface_set_parent(subsurface, parent_surface);
+   wlc_surface_set_parent(convert_from_wlc_resource(surface, "surface"), convert_from_wlc_resource(parent, "surface"));
 }
 
 static void

--- a/src/resources/types/surface.c
+++ b/src/resources/types/surface.c
@@ -185,8 +185,10 @@ wl_cb_surface_set_input_region(struct wl_client *client, struct wl_resource *res
 }
 
 static void
-commit_subsurface_state(struct wlc_surface *surface) {
-   if (!surface) return;
+commit_subsurface_state(struct wlc_surface *surface)
+{
+   if (!surface)
+      return;
 
    commit_state(surface, &surface->pending, &surface->commit);
    wlc_output_schedule_repaint(convert_from_wlc_handle(surface->output, "output"));
@@ -194,8 +196,8 @@ commit_subsurface_state(struct wlc_surface *surface) {
 
    wlc_resource *r;
    chck_iter_pool_for_each(&surface->subsurface_list, r) {
-      struct wlc_surface *sub = convert_from_wlc_resource(*r, "surface");
-      if (!sub)
+      struct wlc_surface *sub;
+      if (!(sub = convert_from_wlc_resource(*r, "surface")))
          continue;
 
       sub->commit.subsurface_position = sub->pending.subsurface_position;
@@ -358,7 +360,9 @@ wlc_surface_release(struct wlc_surface *surface)
    wlc_source_release(&surface->callbacks);
 }
 
-void wlc_surface_commit(struct wlc_surface *surface) {
+void
+wlc_surface_commit(struct wlc_surface *surface)
+{
    assert(surface);
    commit_state(surface, &surface->pending, &surface->commit);
 }


### PR DESCRIPTION
This PR also fixes the GTK3 tooltips not terminating correctly. They will always outlive in parents iter_pool causing terminal to be spammed warnings about bad wlc_resource.